### PR TITLE
Add initial support for extensions.yaml

### DIFF
--- a/Models/Extensions.cs
+++ b/Models/Extensions.cs
@@ -1,0 +1,34 @@
+﻿using Playnite.SDK;
+using Playnite.SDK.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ThemeOptions.Models
+{
+    public class Extensions
+    {
+        private static readonly ILogger logger = LogManager.GetLogger();
+        public List<string> Required { get; set; }
+        public List<string> Recommended { get; set; }
+        static public Extensions FromFile(string path)
+        {
+            if (!File.Exists(path)) return null;
+
+            try
+            {
+                var res = Serialization.FromYamlFile<Extensions>(path);
+                return res;
+            }
+            catch (Exception e)
+            {
+                logger.Error($"Error loading theme option file {path}: \n{e.Message}");
+                return null;
+            }
+        }
+
+    }
+}

--- a/Models/Theme.cs
+++ b/Models/Theme.cs
@@ -16,6 +16,8 @@ namespace ThemeOptions.Models
         public string Path { get; set; }
         public Options Options { get; set; }
 
+        public Extensions Extensions { get; set; }
+
         public List<Preset> PresetList { get => Options.Presets?.Values.ToList() ?? new List<Preset>(); }
         public List<Variable> VariablesList { get => Options.Variables?.Values.ToList() ?? new List<Variable>(); }
 
@@ -39,6 +41,7 @@ namespace ThemeOptions.Models
                 var theme = Serialization.FromYamlFile<Theme>(path);
                 theme.Path =  System.IO.Path.GetDirectoryName(path);
                 theme.Options = Options.FromFile(System.IO.Path.Combine(theme.Path, "options.yaml"));
+                theme.Extensions = Extensions.FromFile(System.IO.Path.Combine(theme.Path, "extensions.yaml"));
                 return theme;
             }
             catch (Exception e)

--- a/ThemeOptions.cs
+++ b/ThemeOptions.cs
@@ -32,6 +32,8 @@ namespace ThemeOptions
 
         public string CurrentThemeId;
 
+        public Extensions MissingExtensions { get; private set; } = new Extensions();
+
         public override Guid Id { get; } = Guid.Parse("904cbf3b-573f-48f8-9642-0a09d05c64ef");
         List<ResourceDictionary> themeResources = new List<ResourceDictionary>();
 
@@ -92,6 +94,39 @@ namespace ThemeOptions
                     }
                 }
             }
+
+
+            var missingRequired = new List<string>();
+            var missingRecommended = new List<string>();
+
+            var installedExtensions = PlayniteAPI.Addons.Addons;
+            if (theme.Extensions?.Required?.Count > 0)
+            {
+                foreach (var ext in theme.Extensions.Required)
+                {
+                    if (!installedExtensions.Exists(a => a.Equals(ext, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        missingRequired.Add(ext);
+                    }
+                }
+            }
+
+            if(theme.Extensions?.Recommended?.Count > 0)
+            {
+                foreach (var ext in theme.Extensions.Recommended)
+                {
+                    if (!installedExtensions.Exists(a => a.Equals(ext, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        missingRecommended.Add(ext);
+                    }
+                }
+            }
+
+            MissingExtensions = new Extensions
+            {
+                Required = missingRequired,
+                Recommended = missingRecommended
+            };
 
             if (PlayniteAPI.ApplicationSettings.Language != "en_US")
             {
@@ -208,6 +243,51 @@ namespace ThemeOptions
                     return new GamepadAltControl(suppressDefaults: true, global: true);
                 default:
                     throw new ArgumentException($"Unrecognized controlType '{controlType}' for request '{args.Name}'");
+            }
+        }
+
+        public override void OnApplicationStarted(OnApplicationStartedEventArgs args)
+        {
+            if (MissingExtensions.Required.Count > 0)
+            {
+                var result = PlayniteAPI.Dialogs.ShowMessage(
+                    $"You are missing {MissingExtensions.Required.Count} required extensions for this theme. Would you like to open their addon pages?",
+                    "Missing Extensions",
+                    MessageBoxButton.YesNo
+                );
+                if (result == MessageBoxResult.Yes)
+                {
+                    foreach (var ext in MissingExtensions.Required)
+                    {
+                        System.Diagnostics.Process.Start($"https://playnite.link/addons.html#{ext}");
+                    }
+                }
+            }  
+
+            if (MissingExtensions.Recommended.Count > 0)
+            {
+                PlayniteAPI.Notifications.Add(
+                    new NotificationMessage(
+                        "ThemeOptions-MissingExtensions",
+                        $"You are missing {MissingExtensions.Recommended.Count} recommended extensions for this theme.",
+                        NotificationType.Info,
+                        () =>
+                        {
+                            var result = PlayniteAPI.Dialogs.ShowMessage(
+                                $"You are missing {MissingExtensions.Recommended.Count} recommended extensions for this theme. Would you like to open their addon pages?",
+                                "Missing Extensions",
+                                MessageBoxButton.YesNo
+                            );
+                            if (result == MessageBoxResult.Yes)
+                            {
+                                foreach (var ext in MissingExtensions.Recommended)
+                                {
+                                    System.Diagnostics.Process.Start($"https://playnite.link/addons.html#{ext}");
+                                }
+                            }
+                        }
+                    )
+                );
             }
         }
 


### PR DESCRIPTION
While I am sure that this isn't fully ready to merge due to localization and UX considerations, here is a proof of concept for managing theme requirements. Theme devs create an `extensions.yaml` file in their theme and populate it with arrays of required and recommended extensions.

Example:
```yaml
Required:
  - PlayniteCopilotAiSlopGenerator_9767ac15-6e26-4e4c-9d69-f6838625dde3
Recommended:
  - System32Deleter_9767ac15-6e26-4e4c-9d69-f6838625dde3
```

Required extensions will cause a dialog to appear when the app launches, but let the user exit the dialog if they so choose. Recommended extensions will generate a notification that, when clicked, creates a similar dialog. Both dialogs prompt the user to open the respective addon pages for installation.